### PR TITLE
(Fix):  Certain redirects caused failed hostname verification

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -32,7 +32,6 @@ func NewTransport() (*http.Transport, error) {
 		DialTLS: func(network, addr string) (net.Conn, error) {
 			conn, err := tls.Dial(network, addr, &tls.Config{
 				InsecureSkipVerify: true,
-				ServerName:         addr,
 				RootCAs:            rootCAs,
 				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 					serverName, _, err := net.SplitHostPort(addr)

--- a/transport_multihop_test.go
+++ b/transport_multihop_test.go
@@ -36,7 +36,7 @@ func TestTransport_multiHopIncompleteChain(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{ "path" : "%s" }`, path)
+		_, _ = fmt.Fprintf(w, `{ "path" : "%s" }`, path)
 	})
 	tlsServer := httptest.NewUnstartedServer(handler)
 	httpServer := httptest.NewServer(handler)


### PR DESCRIPTION
See examples such as:
* https://tucowsdomains.com
* https://api-2-0.spot.im

Todo: Add tests for this case.